### PR TITLE
Add bind command for creating KameletBindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ require (
 	k8s.io/cli-runtime v0.21.4
 	k8s.io/client-go v0.21.4
 	knative.dev/client v0.25.1-0.20210903081157-817068bd7f98
+	knative.dev/eventing v0.25.1-0.20210827141738-ea5ed9adf51f
 	knative.dev/hack v0.0.0-20210806075220-815cd312d65c
 	knative.dev/pkg v0.0.0-20210906105443-bb433c98147d
+	knative.dev/serving v0.25.1-0.20210827140938-e6a7166509e6
 )
 
 replace github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3

--- a/internal/client/client_mock.go
+++ b/internal/client/client_mock.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	camelkapis "github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	camelkv1 "github.com/apache/camel-k/pkg/client/camel/clientset/versioned/typed/camel/v1"
 	camelkv1alpha1 "github.com/apache/camel-k/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
@@ -31,69 +33,99 @@ import (
 	"knative.dev/client/pkg/util/mock"
 )
 
+// MockClient is a combine of test object and recorder
+type MockClient struct {
+	t        *testing.T
+	recorder *KameletRecorder
+}
+
+func (c *MockClient) RESTClient() rest.Interface {
+	panic("should not be called")
+}
+
+// NewMockClient returns a new mock instance which you need to record for
+func NewMockClient(t *testing.T, ns ...string) *MockClient {
+	namespace := "default"
+	if len(ns) > 0 {
+		namespace = ns[0]
+	}
+	return &MockClient{
+		t:        t,
+		recorder: &KameletRecorder{mock.NewRecorder(t, namespace)},
+	}
+}
+
 // MockKameletClient is a combine of test object and recorder
 type MockKameletClient struct {
 	t        *testing.T
 	recorder *KameletRecorder
 }
 
-func (c *MockKameletClient) RESTClient() rest.Interface {
-	panic("should not be called")
+// NewMockKameletClient returns a new mock instance which you need to record for
+func newMockKameletClient(c *MockClient) *MockKameletClient {
+	return &MockKameletClient{
+		t:        c.t,
+		recorder: c.recorder,
+	}
 }
 
-// NewMockKameletClient returns a new mock instance which you need to record for
-func NewMockKameletClient(t *testing.T, ns ...string) *MockKameletClient {
-	namespace := "default"
-	if len(ns) > 0 {
-		namespace = ns[0]
-	}
-	return &MockKameletClient{
-		t:        t,
-		recorder: &KameletRecorder{mock.NewRecorder(t, namespace)},
+// MockKameletBindingsClient is a combine of test object and recorder
+type MockKameletBindingsClient struct {
+	t        *testing.T
+	recorder *KameletRecorder
+}
+
+// NewMockKameletBindingsClient returns a new mock instance which you need to record for
+func newMockKameletBindingsClient(c *MockClient) *MockKameletBindingsClient {
+	return &MockKameletBindingsClient{
+		t:        c.t,
+		recorder: c.recorder,
 	}
 }
 
 // Ensure that the interface is implemented
-var _ camelkv1alpha1.CamelV1alpha1Interface = &MockKameletClient{}
+var _ camelkv1alpha1.CamelV1alpha1Interface = &MockClient{}
 var _ camelkv1alpha1.KameletInterface = &MockKameletClient{}
+var _ camelkv1alpha1.KameletBindingInterface = &MockKameletBindingsClient{}
 
 // KameletRecorder is recorder for eventing objects
 type KameletRecorder struct {
 	r *mock.Recorder
 }
 
-func (c *MockKameletClient) CamelV1() camelkv1.CamelV1Interface {
+func (c *MockClient) CamelV1() camelkv1.CamelV1Interface {
 	panic("implement me")
 }
 
-func (c *MockKameletClient) CamelV1alpha1() *camelkv1alpha1.CamelV1alpha1Interface {
+func (c *MockClient) CamelV1alpha1() *camelkv1alpha1.CamelV1alpha1Interface {
 	var i camelkv1alpha1.CamelV1alpha1Interface = c
 	return &i
 }
 
-func (c *MockKameletClient) GetScheme() *runtime.Scheme {
+func (c *MockClient) GetScheme() *runtime.Scheme {
 	panic("implement me")
 }
 
-func (c *MockKameletClient) GetConfig() *rest.Config {
+func (c *MockClient) GetConfig() *rest.Config {
 	panic("implement me")
 }
 
-func (c *MockKameletClient) GetCurrentNamespace(kubeConfig string) (string, error) {
+func (c *MockClient) GetCurrentNamespace(kubeConfig string) (string, error) {
 	panic("implement me")
 }
 
-func (c *MockKameletClient) Kamelets(namespace string) camelkv1alpha1.KameletInterface {
-	var i camelkv1alpha1.KameletInterface = c
+func (c *MockClient) Kamelets(namespace string) camelkv1alpha1.KameletInterface {
+	var i camelkv1alpha1.KameletInterface = newMockKameletClient(c)
 	return i
 }
 
-func (c *MockKameletClient) KameletBindings(namespace string) camelkv1alpha1.KameletBindingInterface {
-	panic("implement me")
+func (c *MockClient) KameletBindings(namespace string) camelkv1alpha1.KameletBindingInterface {
+	var i camelkv1alpha1.KameletBindingInterface = newMockKameletBindingsClient(c)
+	return i
 }
 
 // Recorder returns the recorder for registering API calls
-func (c *MockKameletClient) Recorder() *KameletRecorder {
+func (c *MockClient) Recorder() *KameletRecorder {
 	return c.recorder
 }
 
@@ -144,6 +176,56 @@ func (c *MockKameletClient) Watch(ctx context.Context, opts v1.ListOptions) (wat
 }
 
 func (c *MockKameletClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *camelkapis.Kamelet, err error) {
+	panic("implement me")
+}
+
+// CreateKameletBinding records a call for CreateKameletBinding with the expected result and error (nil if none)
+func (sr *KameletRecorder) CreateKameletBinding(binding *camelkapis.KameletBinding, err error) {
+	sr.r.Add("Create", nil, []interface{}{binding, err})
+}
+
+// Create performs a previously recorded action
+func (c *MockKameletBindingsClient) Create(ctx context.Context, binding *camelkapis.KameletBinding, opts v1.CreateOptions) (*camelkapis.KameletBinding, error) {
+	call := c.recorder.r.VerifyCall("Create")
+	assert.DeepEqual(c.t, call.Result[0].(*camelkapis.KameletBinding), binding)
+	return call.Result[0].(*camelkapis.KameletBinding), mock.ErrorOrNil(call.Result[1])
+}
+
+func (c *MockKameletBindingsClient) Update(ctx context.Context, binding *camelkapis.KameletBinding, opts v1.UpdateOptions) (*camelkapis.KameletBinding, error) {
+	panic("implement me")
+}
+
+func (c *MockKameletBindingsClient) UpdateStatus(ctx context.Context, binding *camelkapis.KameletBinding, opts v1.UpdateOptions) (*camelkapis.KameletBinding, error) {
+	panic("implement me")
+}
+
+func (c *MockKameletBindingsClient) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+	panic("implement me")
+}
+
+func (c *MockKameletBindingsClient) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	panic("implement me")
+}
+func (c *MockKameletBindingsClient) List(ctx context.Context, opts v1.ListOptions) (*camelkapis.KameletBindingList, error) {
+	panic("implement me")
+}
+
+// GetKameletBinding records a call for Get with the expected result and error (nil if none)
+func (sr *KameletRecorder) GetKameletBinding(binding *camelkapis.KameletBinding, err error) {
+	sr.r.Add("Get", nil, []interface{}{binding, err})
+}
+
+// Get performs a previously recorded action
+func (c *MockKameletBindingsClient) Get(ctx context.Context, name string, opts v1.GetOptions) (*camelkapis.KameletBinding, error) {
+	call := c.recorder.r.VerifyCall("Get")
+	return call.Result[0].(*camelkapis.KameletBinding), mock.ErrorOrNil(call.Result[1])
+}
+
+func (c *MockKameletBindingsClient) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c *MockKameletBindingsClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *camelkapis.KameletBinding, err error) {
 	panic("implement me")
 }
 

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -1,0 +1,299 @@
+/*
+ * Copyright © 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	knerrors "knative.dev/client/pkg/errors"
+	"knative.dev/client/pkg/kn/commands"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var bindExample = `
+  # Bind Kamelets in an integration flow
+  kn-source-kamelet bind SOURCE SINK
+
+  # Add a binding properties
+  kn-source-kamelet bind SOURCE SINK --property=source.<key>=<value>`
+
+// NewBindCommand implements 'kn-source-kamelet bind' command
+func NewBindCommand(p *KameletPluginParams) *cobra.Command {
+	printFlags := genericclioptions.NewPrintFlags("")
+
+	var properties []string
+	cmd := &cobra.Command{
+		Use:     "bind",
+		Short:   "Create KameletBindings and bind Kamelet source to Knative broker, channel or service.",
+		Example: bindExample,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) != 2 {
+				return errors.New("'kn-source-kamelet bind' requires the Kamelet source and the Knative broker, channel or service as argument")
+			}
+			source := args[0]
+			sink := args[1]
+
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := p.NewKameletClient()
+			if err != nil {
+				return err
+			}
+
+			kamelet, err := client.Kamelets(namespace).Get(p.Context, source, v1.GetOptions{})
+			if err != nil {
+				return knerrors.GetError(err)
+			}
+
+			if !isEventSourceType(kamelet) {
+				return fmt.Errorf("kamelet %s is not an event source", source)
+			}
+
+			sourceProperties, err := asEndpointProperties(getProperties("source", properties))
+			if err != nil {
+				return knerrors.GetError(err)
+			}
+			sourceEndpoint := v1alpha1.Endpoint{
+				Properties: &sourceProperties,
+				Ref: &corev1.ObjectReference{
+					Kind:       v1alpha1.KameletKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Name:       kamelet.Name,
+					Namespace:  kamelet.Namespace,
+				},
+			}
+
+			if err := verifyProperties(kamelet, sourceEndpoint); err != nil {
+				return knerrors.GetError(err)
+			}
+
+			channelOrBrokerRef, err := decodeSink(sink)
+			if err != nil {
+				return knerrors.GetError(err)
+			}
+
+			if channelOrBrokerRef.Namespace == "" {
+				channelOrBrokerRef.Namespace = namespace
+			}
+
+			sinkProperties, err := asEndpointProperties(getProperties("sink", properties))
+			if err != nil {
+				return knerrors.GetError(err)
+			}
+			sinkEndpoint := v1alpha1.Endpoint{
+				Properties: &sinkProperties,
+				Ref:        &channelOrBrokerRef,
+			}
+
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return knerrors.GetError(err)
+			}
+
+			name = nameFor(name, source, sink)
+
+			binding := v1alpha1.KameletBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: v1alpha1.KameletBindingSpec{
+					Source: sourceEndpoint,
+					Sink:   sinkEndpoint,
+				},
+			}
+
+			existed := false
+			_, err = client.KameletBindings(namespace).Create(p.Context, &binding, v1.CreateOptions{})
+			if err != nil && k8serrors.IsAlreadyExists(err) {
+				existed = true
+
+				existing, err := client.KameletBindings(namespace).Get(p.Context, binding.Name, v1.GetOptions{})
+				if err != nil {
+					return knerrors.GetError(err)
+				}
+				// Update the custom resource
+				binding.ResourceVersion = existing.ResourceVersion
+				_, err = client.KameletBindings(namespace).Update(p.Context, &binding, v1.UpdateOptions{})
+				if err != nil {
+					return knerrors.GetError(err)
+				}
+			}
+
+			if !existed {
+				fmt.Printf("kamelet binding \"%s\" created\n", name)
+			} else {
+				fmt.Printf("kamelet binding \"%s\" updated\n", name)
+			}
+
+			out := cmd.OutOrStdout()
+			if printFlags.OutputFlagSpecified() {
+				printer, err := printFlags.ToPrinter()
+				if err != nil {
+					return err
+				}
+				return printer.PrintObj(&binding, out)
+			}
+
+			return nil
+		},
+	}
+	flags := cmd.Flags()
+	commands.AddNamespaceFlags(flags, false)
+
+	flags.String("name", "", "Binding name.")
+	flags.StringArrayVarP(&properties, "property", "p", nil, `Add a binding property in the form of "source.<key>=<value>", "sink.<key>=<value>"`)
+
+	printFlags.AddFlags(cmd)
+	cmd.Flag("output").Usage = fmt.Sprintf("Output format. One of: %s.", strings.Join(append(printFlags.AllowedFormats(), "url"), "|"))
+	return cmd
+}
+
+func nameFor(name, source string, sink string) string {
+	if name != "" {
+		return name
+	}
+
+	generated := fmt.Sprintf("%s-to-%s", source, sink)
+
+	generated = filepath.Base(generated)
+	generated = strings.Split(generated, ".")[0]
+	generated = strings.ToLower(generated)
+	generated = disallowedChars.ReplaceAllString(generated, "")
+	generated = strings.TrimFunc(generated, isDisallowedStartEndChar)
+
+	return generated
+}
+
+func decodeSink(sink string) (corev1.ObjectReference, error) {
+	ref := corev1.ObjectReference{}
+
+	if sinkExpression.MatchString(sink) {
+		groupNames := sinkExpression.SubexpNames()
+		ref := corev1.ObjectReference{}
+		for _, match := range sinkExpression.FindAllStringSubmatch(sink, -1) {
+			for idx, text := range match {
+				groupName := groupNames[idx]
+				switch groupName {
+				case "apiVersion":
+					ref.APIVersion = text
+				case "namespace":
+					ref.Namespace = text
+				case "kind":
+					ref.Kind = text
+				case "name":
+					ref.Name = text
+				}
+			}
+		}
+
+		if sinkType, ok := sinkTypes[ref.Kind]; ok {
+			if sinkType.Kind != "" {
+				ref.Kind = sinkType.Kind
+			}
+			if ref.APIVersion == "" && sinkType.APIVersion != "" {
+				ref.APIVersion = sinkType.APIVersion
+			}
+		}
+		return ref, nil
+	}
+
+	ref.Kind = "Channel"
+	ref.APIVersion = messagingv1.SchemeGroupVersion.String()
+
+	return ref, nil
+}
+
+func verifyProperties(kamelet *v1alpha1.Kamelet, endpoint v1alpha1.Endpoint) error {
+	if kamelet.Spec.Definition != nil && len(kamelet.Spec.Definition.Required) > 0 {
+		pMap, err := endpoint.Properties.GetPropertyMap()
+		if err != nil {
+			return err
+		}
+		for _, reqProp := range kamelet.Spec.Definition.Required {
+			found := false
+			if endpoint.Properties != nil {
+				if _, contains := pMap[reqProp]; contains {
+					found = true
+				}
+			}
+			if !found {
+				return fmt.Errorf("binding is missing required property %q for Kamelet %q", reqProp, kamelet.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func getProperties(refType string, properties []string) map[string]string {
+	props := make(map[string]string)
+	for _, p := range properties {
+		tp, key, value, err := parseProperty(p)
+		if err != nil {
+			continue
+		}
+		if tp == refType {
+			props[key] = value
+		}
+	}
+	return props
+}
+
+func asEndpointProperties(props map[string]string) (v1alpha1.EndpointProperties, error) {
+	if len(props) == 0 {
+		return v1alpha1.EndpointProperties{}, nil
+	}
+	data, err := json.Marshal(props)
+	if err != nil {
+		return v1alpha1.EndpointProperties{}, err
+	}
+	return v1alpha1.EndpointProperties{
+		RawMessage: camelv1.RawMessage(data),
+	}, nil
+}
+
+func parseProperty(prop string) (string, string, string, error) {
+	parts := strings.SplitN(prop, "=", 2)
+	if len(parts) != 2 {
+		return "", "", "", fmt.Errorf(`property %q does not follow format "[source|sink|step-<n>].<key>=<value>"`, prop)
+	}
+	keyParts := strings.SplitN(parts[0], ".", 2)
+	if len(keyParts) != 2 {
+		return "", "", "", fmt.Errorf(`property key %q does not follow format "[source|sink|step-<n>].<key>"`, parts[0])
+	}
+	isSource := keyParts[0] == "source"
+	isSink := keyParts[0] == "sink"
+	if !isSource && !isSink {
+		return "", "", "", fmt.Errorf(`property key %q does not start with "source." or "sink."`, parts[0])
+	}
+	return keyParts[0], keyParts[1], parts[1], nil
+}

--- a/internal/command/bind_test.go
+++ b/internal/command/bind_test.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+
+	camelkv1alpha1 "github.com/apache/camel-k/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
+	"knative.dev/client/pkg/kn/commands"
+	"knative.dev/kn-plugin-source-kamelet/internal/client"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBindSetup(t *testing.T) {
+	p := KameletPluginParams{
+		Context: context.TODO(),
+	}
+
+	bindCmd := NewBindCommand(&p)
+	assert.Equal(t, bindCmd.Use, "bind")
+	assert.Equal(t, bindCmd.Short, "Create KameletBindings and bind Kamelet source to Knative broker, channel or service.")
+	assert.Assert(t, bindCmd.RunE != nil)
+}
+func TestBindErrorCaseMissingArgument(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	err := runBindCmd(mockClient)
+	assert.Error(t, err, "'kn-source-kamelet bind' requires the Kamelet source and the Knative sink as argument")
+	recorder.Validate()
+}
+
+func TestBindErrorCaseNotFound(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, errors.New("not found"))
+
+	err := runBindCmd(mockClient, "k1", "channel:test")
+	assert.Error(t, err, "not found")
+	recorder.Validate()
+}
+
+func TestBindErrorCaseNoEventSource(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	kamelet.Labels = map[string]string{
+		KameletTypeLabel: "sink",
+	}
+	recorder.Get(kamelet, nil)
+
+	err := runBindCmd(mockClient, "k1", "channel:test")
+	assert.Error(t, err, "Kamelet k1 is not an event source")
+	recorder.Validate()
+}
+
+func TestBindErrorCaseMissingRequiredProperty(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, nil)
+
+	err := runBindCmd(mockClient, "k1", "channel:test")
+	assert.Error(t, err, "binding is missing required property \"k1_prop\" for Kamelet \"k1\"")
+
+	recorder.Validate()
+}
+
+func TestBindErrorCaseUnsupportedSinkType(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, nil)
+
+	err := runBindCmd(mockClient, "k1", "foo:test", "-p=source.k1_prop=foo")
+	assert.Error(t, err, "unsupported sink type \"foo\"")
+
+	recorder.Validate()
+}
+
+func TestBindErrorCaseUnsupportedSinkExpression(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, nil)
+
+	err := runBindCmd(mockClient, "k1", "foo", "-p=source.k1_prop=foo")
+	assert.Error(t, err, "unsupported sink expression \"foo\" - please use format <kind>:<name>")
+
+	recorder.Validate()
+}
+
+func TestBindToChannel(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	namespace := "current"
+	kamelet := createKameletInNamespace("k1", namespace)
+	recorder.Get(kamelet, nil)
+
+	recorder.CreateKameletBinding(&v1alpha1.KameletBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "k1-to-channeltest",
+		},
+		Spec: v1alpha1.KameletBindingSpec{
+			Source: v1alpha1.Endpoint{
+				Properties: &v1alpha1.EndpointProperties{
+					RawMessage: []byte("{\"k1_prop\":\"foo\"}"),
+				},
+				Ref: &corev1.ObjectReference{
+					Kind:       v1alpha1.KameletKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Namespace:  namespace,
+					Name:       "k1",
+				},
+			},
+			Sink: v1alpha1.Endpoint{
+				Properties: &v1alpha1.EndpointProperties{},
+				Ref: &corev1.ObjectReference{
+					Kind:       "Channel",
+					APIVersion: messagingv1.SchemeGroupVersion.String(),
+					Namespace:  namespace,
+					Name:       "test",
+				},
+			},
+		},
+	}, nil)
+	err := runBindCmd(mockClient, "k1", "channel:test", "-p=source.k1_prop=foo")
+	assert.NilError(t, err)
+
+	recorder.Validate()
+}
+
+func TestBindToBroker(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	namespace := "current"
+	kamelet := createKameletInNamespace("k2", namespace)
+	recorder.Get(kamelet, nil)
+
+	recorder.CreateKameletBinding(&v1alpha1.KameletBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "k2-to-brokertest",
+		},
+		Spec: v1alpha1.KameletBindingSpec{
+			Source: v1alpha1.Endpoint{
+				Properties: &v1alpha1.EndpointProperties{
+					RawMessage: []byte("{\"k2_optional\":\"bar\",\"k2_prop\":\"foo\"}"),
+				},
+				Ref: &corev1.ObjectReference{
+					Kind:       v1alpha1.KameletKind,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Namespace:  namespace,
+					Name:       "k2",
+				},
+			},
+			Sink: v1alpha1.Endpoint{
+				Properties: &v1alpha1.EndpointProperties{},
+				Ref: &corev1.ObjectReference{
+					Kind:       "Broker",
+					APIVersion: eventingv1.SchemeGroupVersion.String(),
+					Namespace:  namespace,
+					Name:       "test",
+				},
+			},
+		},
+	}, nil)
+	err := runBindCmd(mockClient, "k2", "broker:test", "-p=source.k2_prop=foo", "-psource.k2_optional=bar")
+	assert.NilError(t, err)
+
+	recorder.Validate()
+}
+
+func runBindCmd(c *client.MockClient, options ...string) error {
+	p := KameletPluginParams{
+		KnParams: &commands.KnParams{},
+		Context:  context.TODO(),
+		NewKameletClient: func() (camelkv1alpha1.CamelV1alpha1Interface, error) {
+			return c, nil
+		},
+	}
+
+	bindCmd, _, _ := commands.CreateSourcesTestKnCommand(NewBindCommand(&p), p.KnParams)
+
+	args := []string{"bind"}
+	args = append(args, options...)
+	bindCmd.SetArgs(args)
+	err := bindCmd.Execute()
+
+	return err
+}

--- a/internal/command/describe_type.go
+++ b/internal/command/describe_type.go
@@ -183,14 +183,6 @@ func getMaxPropertyNameLen(properties map[string]v1alpha1.JSONSchemaProps) strin
 	return strconv.Itoa(max)
 }
 
-func extractKameletProvider(kamelet *v1alpha1.Kamelet) string {
-	return kamelet.Labels["camel.apache.org/kamelet.provider"]
-}
-
-func isEventSourceType(kamelet *v1alpha1.Kamelet) bool {
-	return kamelet.Labels["camel.apache.org/kamelet.type"] == "source"
-}
-
 func asApiConditions(conditions []v1alpha1.KameletCondition) apis.Conditions {
 	var aConditions apis.Conditions
 

--- a/internal/command/describe_type_test.go
+++ b/internal/command/describe_type_test.go
@@ -41,7 +41,7 @@ func TestDescribeTypeSetup(t *testing.T) {
 	assert.Assert(t, describeCmd.RunE != nil)
 }
 func TestDescribeTypeErrorCase(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	_, err := runDescribeTypeCmd(mockClient)
@@ -50,7 +50,7 @@ func TestDescribeTypeErrorCase(t *testing.T) {
 }
 
 func TestDescribeTypeErrorCaseNotFound(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
@@ -62,12 +62,12 @@ func TestDescribeTypeErrorCaseNotFound(t *testing.T) {
 }
 
 func TestDescribeTypeErrorCaseNoEventSource(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
 	kamelet.Labels = map[string]string{
-		"camel.apache.org/kamelet.type": "sink",
+		KameletTypeLabel: "sink",
 	}
 	recorder.Get(kamelet, nil)
 
@@ -77,7 +77,7 @@ func TestDescribeTypeErrorCaseNoEventSource(t *testing.T) {
 }
 
 func TestDescribeTypeOutput(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
@@ -106,7 +106,7 @@ func TestDescribeTypeOutput(t *testing.T) {
 }
 
 func TestDescribeTypeVerboseOutput(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
@@ -139,7 +139,7 @@ func TestDescribeTypeVerboseOutput(t *testing.T) {
 }
 
 func TestDescribeTypeURL(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
@@ -154,7 +154,7 @@ func TestDescribeTypeURL(t *testing.T) {
 	recorder.Validate()
 }
 
-func runDescribeTypeCmd(c *client.MockKameletClient, options ...string) (string, error) {
+func runDescribeTypeCmd(c *client.MockClient, options ...string) (string, error) {
 	p := KameletPluginParams{
 		KnParams: &commands.KnParams{},
 		Context:  context.TODO(),

--- a/internal/command/helpers_test.go
+++ b/internal/command/helpers_test.go
@@ -41,8 +41,8 @@ func createKameletInNamespace(kameletName string, namespace string) *camelkv1alp
 			Name:              kameletName,
 			CreationTimestamp: v1.Now(),
 			Labels: map[string]string{
-				"camel.apache.org/kamelet.type":     "source",
-				"camel.apache.org/kamelet.provider": "Community",
+				KameletTypeLabel:     "source",
+				KameletProviderLabel: "Community",
 			},
 			SelfLink: fmt.Sprintf("/apis/camel.apache.org/v1alpha1/namespaces/default/kamelets/%s", kameletName),
 		},

--- a/internal/command/list_types.go
+++ b/internal/command/list_types.go
@@ -58,7 +58,11 @@ func NewListTypesCommand(p *KameletPluginParams) *cobra.Command {
 				return err
 			}
 
-			kameletList, err := kameletClient.Kamelets(namespace).List(p.Context, v1.ListOptions{})
+			filterCriteria := v1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", KameletTypeLabel, "source"),
+			}
+
+			kameletList, err := kameletClient.Kamelets(namespace).List(p.Context, filterCriteria)
 			if err != nil {
 				return err
 			}

--- a/internal/command/list_types_test.go
+++ b/internal/command/list_types_test.go
@@ -42,7 +42,7 @@ func TestListTypesSetup(t *testing.T) {
 }
 
 func TestListTypesOutput(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet1 := createKamelet("k1")
@@ -65,7 +65,7 @@ func TestListTypesOutput(t *testing.T) {
 }
 
 func TestListTypesEmpty(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	recorder.List(&camelkapis.KameletList{}, nil)
@@ -78,7 +78,7 @@ func TestListTypesEmpty(t *testing.T) {
 }
 
 func TestListTypesNoReadyReasonOutput(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet1 := createKamelet("k1")
@@ -107,7 +107,7 @@ func TestListTypesNoReadyReasonOutput(t *testing.T) {
 }
 
 func TestListTypesAllNamespace(t *testing.T) {
-	mockClient := client.NewMockKameletClient(t)
+	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet1 := createKameletInNamespace("k1", "default1")
@@ -128,7 +128,7 @@ func TestListTypesAllNamespace(t *testing.T) {
 	recorder.Validate()
 }
 
-func runListTypesCmd(c *client.MockKameletClient, options ...string) (string, error) {
+func runListTypesCmd(c *client.MockClient, options ...string) (string, error) {
 	p := KameletPluginParams{
 		KnParams: &commands.KnParams{},
 		Context:  context.TODO(),

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -18,10 +18,36 @@ package command
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	camelk "github.com/apache/camel-k/pkg/client/camel/clientset/versioned"
 	camelkv1alpha1 "github.com/apache/camel-k/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
 	"knative.dev/client/pkg/kn/commands"
+)
+
+const (
+	KameletTypeLabel     = "camel.apache.org/kamelet.type"
+	KameletProviderLabel = "camel.apache.org/kamelet.provider"
+)
+
+var (
+	sinkTypes = map[string]corev1.ObjectReference{
+		"channel": {
+			Kind:       "Channel",
+			APIVersion: messagingv1.SchemeGroupVersion.String(),
+		},
+		"broker": {
+			Kind:       "Broker",
+			APIVersion: eventingv1.SchemeGroupVersion.String(),
+		},
+		"service": {
+			Kind:       "Service",
+			APIVersion: servingv1.SchemeGroupVersion.String(),
+		},
+	}
 )
 
 // KnParams for creating commands. Useful for inserting mocks for testing.

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -17,9 +17,10 @@
 package command
 
 import (
-	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"regexp"
 	"unicode"
+
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 )
 
 var (

--- a/internal/command/util.go
+++ b/internal/command/util.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	"regexp"
+	"unicode"
+)
+
+var (
+	disallowedChars = regexp.MustCompile(`[^a-z0-9-]`)
+	sinkExpression  = regexp.MustCompile(`^(?:(?P<apiVersion>(?:[a-z0-9-.]+/)?[a-z0-9-.]+):)?(?P<kind>[A-Za-z0-9-.]+):(?:(?P<namespace>[a-z0-9-.]+)/)?(?P<name>[a-z0-9-.]+)(?:$|[?].*$)`)
+)
+
+func isEventSourceType(kamelet *v1alpha1.Kamelet) bool {
+	return kamelet.Labels[KameletTypeLabel] == "source"
+}
+
+func extractKameletProvider(kamelet *v1alpha1.Kamelet) string {
+	return kamelet.Labels[KameletProviderLabel]
+}
+
+func isDisallowedStartEndChar(rune rune) bool {
+	return !unicode.IsLetter(rune) && !unicode.IsNumber(rune)
+}

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -40,6 +40,7 @@ func NewSourceKameletCommand() *cobra.Command {
 
 	rootCmd.AddCommand(command.NewListTypesCommand(p))
 	rootCmd.AddCommand(command.NewDescribeTypeCommand(p))
+	rootCmd.AddCommand(command.NewBindCommand(p))
 	rootCmd.AddCommand(command.NewVersionCommand())
 
 	return rootCmd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -657,6 +657,7 @@ knative.dev/client/pkg/util
 knative.dev/client/pkg/util/mock
 knative.dev/client/pkg/wait
 # knative.dev/eventing v0.25.1-0.20210827141738-ea5ed9adf51f
+## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
 knative.dev/eventing/pkg/apis/duck/v1
@@ -719,6 +720,7 @@ knative.dev/pkg/system
 knative.dev/pkg/tracker
 knative.dev/pkg/unstructured
 # knative.dev/serving v0.25.1-0.20210827140938-e6a7166509e6
+## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
 knative.dev/serving/pkg/apis/config


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Add bind command for creating KameletBindings
- List only Kamelets of type source
- Add test coverage on bind command

<!-- Please include the 'why' behind your changes if no issue exists -->

## Command

_Bind Kamelets in an integration flow_
`kn-source-kamelet bind <source> <sink>`

The `bind` command creates a KameletBinding with a Kamelet as source and a Knative broker, channel or service as sink. The sink type gets specified with the respective prefix `broker:`, `channel:` or `service:`.

_Add a binding properties_
`kn-source-kamelet bind <source> <sink> --property=source.<key>=<value> --property=sink.<key>=<value>`

Source and sink can receive properties where the Kamelet defines optional and required properties that need to be set in the bind command. Properties are prefixed with `source.` or `sink.` and specify a `key=value` property. The `bind` command verifies the given properties and raises errors when something is missing.

## Sample command
`kn-source-kamelet bind timer-source channel:messages --property=source.message=Hello --property=source.period=1000`

This command creates a new KameletBinding with the Kamelet `timer-source` sending `Hello` to the Knative channel `messages` periodically every 1000 ms.

## Naming

The user is able to specify a name for the KameletBinding.
`kn-source-kamelet bind timer-source channel:messages --name timer-to-knative`

When no explicit name is given the command will generate a binding name from given source and sink.

## Auto update

In case the KameletBinding already exists the `bind` command will auto update the binding.
