### PR TITLE
Introduce Kamelet binding create command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ Examples:
   kn-source-kamelet binding create NAME
 
   # Add a binding properties
-  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value>
+  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --property=<key>=<value>
 
 Flags:
       --broker string                 Uses a broker as binding sink.
@@ -135,7 +135,7 @@ Flags:
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
       --sink string                   Sink expression to define the binding sink.
-      --source-property stringArray   Add a source property in the form of "<key>=<value>"
+      --property stringArray   Add a source property in the form of "<key>=<value>"
 ----
 
 === `bind`
@@ -155,7 +155,7 @@ Examples:
   kn-source-kamelet bind SOURCE
 
   # Add a binding properties
-  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --source-property=<key>=<value>
+  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --property=<key>=<value>
 
 Flags:
       --broker string                 Uses a broker as binding sink.
@@ -166,7 +166,7 @@ Flags:
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
       --sink string                   Sink expression to define the binding sink.
-      --source-property stringArray   Add a source property in the form of "<key>=<value>"
+      --property stringArray   Add a source property in the form of "<key>=<value>"
 ----
 
 === `version`

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,6 @@ Flags:
   -h, --help                          help for create
       --kamelet string                Kamelet source.
   -n, --namespace string              Specify the namespace to operate in.
-  -o, --output string                 Output format. One of: json|yaml|name|url.
       --service string                Uses a Knative service as binding sink.
       --sink string                   Sink expression to define the binding sink.
       --source-property stringArray   Add a source property in the form of "<key>=<value>"
@@ -163,7 +162,6 @@ Flags:
   -h, --help                          help for bind
       --name string                   Binding name.
   -n, --namespace string              Specify the namespace to operate in.
-  -o, --output string                 Output format. One of: json|yaml|name|url.
       --service string                Uses a Knative service as binding sink.
       --sink string                   Sink expression to define the binding sink.
       --source-property stringArray   Add a source property in the form of "<key>=<value>"

--- a/README.adoc
+++ b/README.adoc
@@ -82,12 +82,9 @@ Examples:
   kn-source-kamelet describe-type NAME -o yaml
 
 Flags:
-      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for describe-type
   -n, --namespace string              Specify the namespace to operate in.
-  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
-      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
-      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+  -o, --output string                 Output format. One of: json|yaml|name|url.
   -v, --verbose                       More output.
 ----
 
@@ -127,22 +124,18 @@ Examples:
   kn-source-kamelet binding create NAME
 
   # Add a binding properties
-  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value> --sink-property=<key>=<value>
+  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value>
 
 Flags:
-      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
       --broker string                 Uses a broker as binding sink.
       --channel string                Uses a channel as binding sink.
   -h, --help                          help for create
       --kamelet string                Kamelet source.
   -n, --namespace string              Specify the namespace to operate in.
-  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
+  -o, --output string                 Output format. One of: json|yaml|name|url.
       --service string                Uses a Knative service as binding sink.
-      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
       --sink string                   Sink expression to define the binding sink.
-      --sink-property stringArray     Add a sink property in the form of "<key>=<value>"
       --source-property stringArray   Add a source property in the form of "<key>=<value>"
-      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ----
 
 === `bind`
@@ -162,22 +155,18 @@ Examples:
   kn-source-kamelet bind SOURCE
 
   # Add a binding properties
-  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --source-property=<key>=<value> --sink-property=<key>=<value>
+  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --source-property=<key>=<value>
 
 Flags:
-      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
       --broker string                 Uses a broker as binding sink.
       --channel string                Uses a channel as binding sink.
   -h, --help                          help for bind
       --name string                   Binding name.
   -n, --namespace string              Specify the namespace to operate in.
-  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
+  -o, --output string                 Output format. One of: json|yaml|name|url.
       --service string                Uses a Knative service as binding sink.
-      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
       --sink string                   Sink expression to define the binding sink.
-      --sink-property stringArray     Add a sink property in the form of "<key>=<value>"
       --source-property stringArray   Add a source property in the form of "<key>=<value>"
-      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ----
 
 === `version`

--- a/README.adoc
+++ b/README.adoc
@@ -134,7 +134,7 @@ Flags:
       --kamelet string                Kamelet source.
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
-      --sink string                   Sink expression to define the binding sink.
+  -s  --sink string                   Sink expression to define the binding sink.
       --property stringArray   Add a source property in the form of "<key>=<value>"
 ----
 
@@ -165,7 +165,7 @@ Flags:
       --name string                   Binding name.
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
-      --sink string                   Sink expression to define the binding sink.
+  -s  --sink string                   Sink expression to define the binding sink.
       --property stringArray   Add a source property in the form of "<key>=<value>"
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,43 +1,186 @@
-== kn-source-kamelet
+= kn-source-kamelet
 
-`kn-source-kamelet` Knative eventing sources plugin manages Kamelet sources on your cluster.
+`kn-source-kamelet` Knative eventing sources plugin manages Kamelet event sources on your cluster.
 
-=== Description
+== Description
 
-With this plugin, you can list available Kamelets and use those in KameletBindings as Knative eventing sources.
+With this plugin, you can list available Kamelets and bindings on your cluster.
+Kamelets can act as Knative eventing sources where each binding connects a Kamelet source to a Knative sink (broker, channel, service).
 
-=== Usage
+== Usage
 
 ----
-Manages Kamelets and KameletBindings as Knative eventing sources.
+Plugin manages Kamelets and KameletBindings as Knative eventing sources.
 
 Usage:
   kn-source-kamelet [command]
 
 Available Commands:
-  help        Help about any command
-  list        List available Kamelet sources
-  version     Prints the plugin version
+  bind          Create Kamelet bindings and bind source to Knative broker, channel or service.
+  binding       Configure and manage a Kamelet binding.
+  completion    generate the autocompletion script for the specified shell
+  describe-type Show details of given Kamelet source type
+  help          Help about any command
+  list-types    List available Kamelet source types
+  version       Prints the plugin version
 
 Flags:
-  -h, --help   help for kn-plugin-source-kamelet
+  -h, --help   help for kn-source-kamelet
 
 Use "kn-source-kamelet [command] --help" for more information about a command.
 ----
 
-==== `kn-source-kamelet list`
+== Commands
+
+=== `list-types`
 
 ----
-List available Kamelet sources
+List available Kamelet source types
 
 Usage:
-  kn-source-kamelet list [flags]
+  kn-source-kamelet list-types [flags]
+
+Aliases:
+  list-types, lst
+
+Examples:
+
+  # List available Kamelets
+  kn-source-kamelet list-types
+
+  # List available Kamelets in YAML output format
+  kn-source-kamelet list-types -o yaml
 
 Flags:
-  -h, --help   help for list
+  -A, --all-namespaces                If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for list-types
+  -n, --namespace string              Specify the namespace to operate in.
+      --no-headers                    When using the default output format, don't print headers (default: print headers).
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ----
 
-==== `kn-source-kamelet version`
+=== `describe-type`
+
+----
+Show details of given Kamelet source type
+
+Usage:
+  kn-source-kamelet describe-type [flags]
+
+Aliases:
+  describe-type, dt
+
+Examples:
+
+  # Describe given Kamelets
+  kn-source-kamelet describe-type NAME
+
+  # Describe given Kamelets in YAML output format
+  kn-source-kamelet describe-type NAME -o yaml
+
+Flags:
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for describe-type
+  -n, --namespace string              Specify the namespace to operate in.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+  -v, --verbose                       More output.
+----
+
+=== `binding`
+
+----
+Configure and manage a Kamelet binding.
+
+Usage:
+  kn-source-kamelet binding [command]
+
+Examples:
+
+  # Configure and manage a Kamelet binding.
+  kn-source-kamelet binding create|update|delete
+
+Available Commands:
+  create      Create Kamelet bindings and bind source to Knative broker, channel or service.
+
+Flags:
+  -h, --help   help for binding
+
+Use "kn-source-kamelet binding [command] --help" for more information about a command.
+----
+
+==== `binding create`
+
+----
+Create Kamelet bindings and bind source to Knative broker, channel or service.
+
+Usage:
+  kn-source-kamelet binding create [flags]
+
+Examples:
+
+  # Create Kamelet binding with source and sink.
+  kn-source-kamelet binding create NAME
+
+  # Add a binding properties
+  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value> --sink-property=<key>=<value>
+
+Flags:
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --broker string                 Uses a broker as binding sink.
+      --channel string                Uses a channel as binding sink.
+  -h, --help                          help for create
+      --kamelet string                Kamelet source.
+  -n, --namespace string              Specify the namespace to operate in.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
+      --service string                Uses a Knative service as binding sink.
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --sink string                   Sink expression to define the binding sink.
+      --sink-property stringArray     Add a sink property in the form of "<key>=<value>"
+      --source-property stringArray   Add a source property in the form of "<key>=<value>"
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+----
+
+=== `bind`
+
+Shortcut version of `kn-source-kamelet binding create` with Kamelet source as positional argument.
+The shortcut command auto generates a binding name in case no explicit name is given as command option `--name`.
+
+----
+Create Kamelet bindings and bind source to Knative broker, channel or service.
+
+Usage:
+  kn-source-kamelet bind [flags]
+
+Examples:
+
+  # Bind Kamelets to a Knative sink
+  kn-source-kamelet bind SOURCE
+
+  # Add a binding properties
+  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --source-property=<key>=<value> --sink-property=<key>=<value>
+
+Flags:
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --broker string                 Uses a broker as binding sink.
+      --channel string                Uses a channel as binding sink.
+  -h, --help                          help for bind
+      --name string                   Binding name.
+  -n, --namespace string              Specify the namespace to operate in.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|url.
+      --service string                Uses a Knative service as binding sink.
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --sink string                   Sink expression to define the binding sink.
+      --sink-property stringArray     Add a sink property in the form of "<key>=<value>"
+      --source-property stringArray   Add a source property in the form of "<key>=<value>"
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+----
+
+=== `version`
 
 This command prints out the version of this plugin and all extra information which might help, for example when creating
 bug reports.
@@ -52,9 +195,9 @@ Flags:
   -h, --help   help for version
 ----
 
-=== Examples
+== Examples
 
-==== List available Kamelet sources
+=== List available Kamelet sources
 
 You want to list all available Kamelets on your cluster.
 In this case, you can use the `kn-source-kamelet list` command.
@@ -70,7 +213,7 @@ Kamelet_3
 ----
 ====
 
-==== Print out the version of this plugin
+=== Print out the version of this plugin
 
 The `kn-source-kamelet version` command helps you to identify the version of this plugin.
 

--- a/README.adoc
+++ b/README.adoc
@@ -130,6 +130,7 @@ Flags:
       --broker string                 Uses a broker as binding sink.
       --channel string                Uses a channel as binding sink.
   -h, --help                          help for create
+      --force bool                    Apply the changes even if the binding already exists.
       --kamelet string                Kamelet source.
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
@@ -160,6 +161,7 @@ Flags:
       --broker string                 Uses a broker as binding sink.
       --channel string                Uses a channel as binding sink.
   -h, --help                          help for bind
+      --force bool                    Apply the changes even if the binding already exists.
       --name string                   Binding name.
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.

--- a/internal/client/client_mock.go
+++ b/internal/client/client_mock.go
@@ -192,7 +192,13 @@ func (c *MockKameletBindingsClient) Create(ctx context.Context, binding *camelka
 }
 
 func (c *MockKameletBindingsClient) Update(ctx context.Context, binding *camelkapis.KameletBinding, opts v1.UpdateOptions) (*camelkapis.KameletBinding, error) {
-	panic("implement me")
+	call := c.recorder.r.VerifyCall("Update")
+	return call.Result[0].(*camelkapis.KameletBinding), mock.ErrorOrNil(call.Result[1])
+}
+
+// UpdateKameletBinding records a call for Update with the expected result and error (nil if none)
+func (sr *KameletRecorder) UpdateKameletBinding(binding *camelkapis.KameletBinding, err error) {
+	sr.r.Add("Update", nil, []interface{}{binding, err})
 }
 
 func (c *MockKameletBindingsClient) UpdateStatus(ctx context.Context, binding *camelkapis.KameletBinding, opts v1.UpdateOptions) (*camelkapis.KameletBinding, error) {

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -29,11 +29,11 @@ var bindExample = `
   kn-source-kamelet bind SOURCE
 
   # Add a binding properties
-  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --source-property=<key>=<value>`
+  kn-source-kamelet bind SOURCE --sink|broker|channel|service=<name> --property=<key>=<value>`
 
 // NewBindCommand implements 'kn-source-kamelet bind' command
 func NewBindCommand(p *KameletPluginParams) *cobra.Command {
-	var sourceProperties []string
+	var properties []string
 	var sink string
 	var broker string
 	var channel string
@@ -66,7 +66,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 			options := CreateBindingOptions{
 				Name:             name,
 				Source:           source,
-				SourceProperties: sourceProperties,
+				SourceProperties: properties,
 				Sink:             sink,
 				Broker:           broker,
 				Channel:          channel,
@@ -90,6 +90,6 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	flags.StringVar(&broker, "broker", "", "Uses a broker as binding sink.")
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")
-	flags.StringArrayVar(&sourceProperties, "source-property", nil, `Add a source property in the form of "<key>=<value>"`)
+	flags.StringArrayVar(&properties, "property", nil, `Add a source property in the form of "<key>=<value>"`)
 	return cmd
 }

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	knerrors "knative.dev/client/pkg/errors"

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -86,7 +86,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	commands.AddNamespaceFlags(flags, false)
 
 	flags.String("name", "", "Binding name.")
-	flags.StringVar(&sink, "sink", "", "Sink expression to define the binding sink.")
+	flags.StringVarP(&sink, "sink", "s", "", "Sink expression to define the binding sink.")
 	flags.StringVar(&broker, "broker", "", "Uses a broker as binding sink.")
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -17,25 +17,18 @@
 package command
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
-	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	knerrors "knative.dev/client/pkg/errors"
 	"knative.dev/client/pkg/kn/commands"
 )
 
 var bindExample = `
-  # Bind Kamelets in an integration flow
+  # Bind Kamelets to a Knative sink
   kn-source-kamelet bind SOURCE
 
   # Add a binding properties
@@ -53,7 +46,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	var service string
 	cmd := &cobra.Command{
 		Use:     "bind",
-		Short:   "Create KameletBindings and bind Kamelet source to Knative broker, channel or service.",
+		Short:   "Create Kamelet bindings and bind source to Knative broker, channel or service.",
 		Example: bindExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
@@ -71,102 +64,25 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 				return err
 			}
 
-			kamelet, err := client.Kamelets(namespace).Get(p.Context, source, v1.GetOptions{})
-			if err != nil {
-				return knerrors.GetError(err)
-			}
-
-			if !isEventSourceType(kamelet) {
-				return fmt.Errorf("Kamelet %s is not an event source", source)
-			}
-
-			sourceProps, err := parseProperties(sourceProperties)
-			if err != nil {
-				return knerrors.GetError(err)
-			}
-			sourceEndpoint := v1alpha1.Endpoint{
-				Properties: &sourceProps,
-				Ref: &corev1.ObjectReference{
-					Kind:       v1alpha1.KameletKind,
-					APIVersion: v1alpha1.SchemeGroupVersion.String(),
-					Name:       kamelet.Name,
-					Namespace:  kamelet.Namespace,
-				},
-			}
-
-			if err := verifyProperties(kamelet, sourceEndpoint); err != nil {
-				return knerrors.GetError(err)
-			}
-
-			var sinkRef corev1.ObjectReference
-			if sink != "" {
-				sinkRef, err = decodeSink(sink)
-			} else if broker != "" {
-				sinkRef, err = decodeSink("broker:" + broker)
-			} else if channel != "" {
-				sinkRef, err = decodeSink("channel:" + channel)
-			} else if service != "" {
-				sinkRef, err = decodeSink("service:" + service)
-			} else {
-				err = fmt.Errorf("missing sink for binding - please use one of --sink, --broker, --channel, --service")
-			}
-
-			if err != nil {
-				return knerrors.GetError(err)
-			}
-
-			if sinkRef.Namespace == "" {
-				sinkRef.Namespace = namespace
-			}
-
-			sinkProps, err := parseProperties(sinkProperties)
-			if err != nil {
-				return knerrors.GetError(err)
-			}
-			sinkEndpoint := v1alpha1.Endpoint{
-				Properties: &sinkProps,
-				Ref:        &sinkRef,
-			}
-
 			name, err := cmd.Flags().GetString("name")
 			if err != nil {
 				return knerrors.GetError(err)
 			}
 
-			name = nameFor(name, source, sinkRef)
-
-			binding := v1alpha1.KameletBinding{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: namespace,
-					Name:      name,
-				},
-				Spec: v1alpha1.KameletBindingSpec{
-					Source: sourceEndpoint,
-					Sink:   sinkEndpoint,
-				},
+			options := CreateBindingOptions{
+				Name:             name,
+				Source:           source,
+				SourceProperties: sourceProperties,
+				Sink:             sink,
+				SinkProperties:   sinkProperties,
+				Broker:           broker,
+				Channel:          channel,
+				Service:          service,
 			}
 
-			existed := false
-			_, err = client.KameletBindings(namespace).Create(p.Context, &binding, v1.CreateOptions{})
-			if err != nil && k8serrors.IsAlreadyExists(err) {
-				existed = true
-
-				existing, err := client.KameletBindings(namespace).Get(p.Context, binding.Name, v1.GetOptions{})
-				if err != nil {
-					return knerrors.GetError(err)
-				}
-				// Update the custom resource
-				binding.ResourceVersion = existing.ResourceVersion
-				_, err = client.KameletBindings(namespace).Update(p.Context, &binding, v1.UpdateOptions{})
-				if err != nil {
-					return knerrors.GetError(err)
-				}
-			}
-
-			if !existed {
-				fmt.Printf("kamelet binding \"%s\" created\n", name)
-			} else {
-				fmt.Printf("kamelet binding \"%s\" updated\n", name)
+			binding, err := createBinding(client, p.Context, namespace, options)
+			if err != nil {
+				return err
 			}
 
 			out := cmd.OutOrStdout()
@@ -175,7 +91,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				return printer.PrintObj(&binding, out)
+				return printer.PrintObj(binding, out)
 			}
 
 			return nil
@@ -195,113 +111,4 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	printFlags.AddFlags(cmd)
 	cmd.Flag("output").Usage = fmt.Sprintf("Output format. One of: %s.", strings.Join(append(printFlags.AllowedFormats(), "url"), "|"))
 	return cmd
-}
-
-func nameFor(name, source string, sinkRef corev1.ObjectReference) string {
-	if name != "" {
-		return name
-	}
-
-	generated := fmt.Sprintf("%s-to-%s-%s", source, sinkRef.Kind, sinkRef.Name)
-
-	generated = filepath.Base(generated)
-	generated = strings.Split(generated, ".")[0]
-	generated = strings.ToLower(generated)
-	generated = disallowedChars.ReplaceAllString(generated, "")
-	generated = strings.TrimFunc(generated, isDisallowedStartEndChar)
-
-	return generated
-}
-
-func decodeSink(sink string) (corev1.ObjectReference, error) {
-	ref := corev1.ObjectReference{}
-
-	if sinkExpression.MatchString(sink) {
-		groupNames := sinkExpression.SubexpNames()
-		for _, match := range sinkExpression.FindAllStringSubmatch(sink, -1) {
-			for idx, text := range match {
-				groupName := groupNames[idx]
-				switch groupName {
-				case "apiVersion":
-					ref.APIVersion = text
-				case "namespace":
-					ref.Namespace = text
-				case "kind":
-					ref.Kind = text
-				case "name":
-					ref.Name = text
-				}
-			}
-		}
-
-		if sinkType, ok := sinkTypes[ref.Kind]; ok {
-			if sinkType.Kind != "" {
-				ref.Kind = sinkType.Kind
-			}
-			if ref.APIVersion == "" && sinkType.APIVersion != "" {
-				ref.APIVersion = sinkType.APIVersion
-			}
-		} else {
-			return ref, fmt.Errorf("unsupported sink type %q", ref.Kind)
-		}
-	} else {
-		return ref, fmt.Errorf("unsupported sink expression %q - please use format <kind>:<name>", sink)
-	}
-
-	return ref, nil
-}
-
-func verifyProperties(kamelet *v1alpha1.Kamelet, endpoint v1alpha1.Endpoint) error {
-	if kamelet.Spec.Definition != nil && len(kamelet.Spec.Definition.Required) > 0 {
-		pMap, err := endpoint.Properties.GetPropertyMap()
-		if err != nil {
-			return err
-		}
-		for _, reqProp := range kamelet.Spec.Definition.Required {
-			found := false
-			if endpoint.Properties != nil {
-				if _, contains := pMap[reqProp]; contains {
-					found = true
-				}
-			}
-			if !found {
-				return fmt.Errorf("binding is missing required property %q for Kamelet %q", reqProp, kamelet.Name)
-			}
-		}
-	}
-
-	return nil
-}
-
-func parseProperties(properties []string) (v1alpha1.EndpointProperties, error) {
-	props := make(map[string]string)
-	for _, p := range properties {
-		key, value, err := parseProperty(p)
-		if err != nil {
-			continue
-		}
-		props[key] = value
-	}
-	return asEndpointProperties(props)
-}
-
-func asEndpointProperties(props map[string]string) (v1alpha1.EndpointProperties, error) {
-	if len(props) == 0 {
-		return v1alpha1.EndpointProperties{}, nil
-	}
-	data, err := json.Marshal(props)
-	if err != nil {
-		return v1alpha1.EndpointProperties{}, err
-	}
-	return v1alpha1.EndpointProperties{
-		RawMessage: camelv1.RawMessage(data),
-	}, nil
-}
-
-func parseProperty(prop string) (string, string, error) {
-	parts := strings.SplitN(prop, "=", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf(`property %q does not follow format "<key>=<value>"`, prop)
-	}
-	return parts[0], parts[1], nil
 }

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -71,6 +71,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 				Broker:           broker,
 				Channel:          channel,
 				Service:          service,
+				Force:            true,
 			}
 
 			err = createBinding(client, p.Context, namespace, options)

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	knerrors "knative.dev/client/pkg/errors"
 	"knative.dev/client/pkg/kn/commands"
 )
@@ -39,7 +38,6 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	var broker string
 	var channel string
 	var service string
-	var output string
 	cmd := &cobra.Command{
 		Use:     "bind",
 		Short:   "Create Kamelet bindings and bind source to Knative broker, channel or service.",
@@ -75,20 +73,9 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 				Service:          service,
 			}
 
-			binding, err := createBinding(client, p.Context, namespace, options)
+			err = createBinding(client, p.Context, namespace, options)
 			if err != nil {
 				return err
-			}
-
-			if cmd.Flag("output").Changed {
-				out := cmd.OutOrStdout()
-				printFlags := genericclioptions.NewPrintFlags("")
-				printFlags.WithDefaultOutput(output)
-				printer, err := printFlags.ToPrinter()
-				if err != nil {
-					return err
-				}
-				return printer.PrintObj(binding, out)
 			}
 
 			return nil
@@ -103,6 +90,5 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")
 	flags.StringArrayVar(&sourceProperties, "source-property", nil, `Add a source property in the form of "<key>=<value>"`)
-	flags.StringVarP(&output, "output", "o", "", "Output format. One of: json|yaml|name|url")
 	return cmd
 }

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -72,6 +72,7 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 				Channel:          channel,
 				Service:          service,
 				Force:            true,
+				CmdOut:           cmd.OutOrStdout(),
 			}
 
 			err = createBinding(client, p.Context, namespace, options)

--- a/internal/command/bind_test.go
+++ b/internal/command/bind_test.go
@@ -146,7 +146,6 @@ func TestBindToChannel(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Channel",
 					APIVersion: messagingv1.SchemeGroupVersion.String(),
@@ -188,7 +187,6 @@ func TestBindToBroker(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Broker",
 					APIVersion: eventingv1.SchemeGroupVersion.String(),
@@ -230,7 +228,6 @@ func TestBindToService(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Service",
 					APIVersion: servingv1.SchemeGroupVersion.String(),

--- a/internal/command/bind_test.go
+++ b/internal/command/bind_test.go
@@ -94,6 +94,19 @@ func TestBindErrorCaseMissingRequiredProperty(t *testing.T) {
 	recorder.Validate()
 }
 
+func TestBindErrorCaseUnknownProperty(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, nil)
+
+	err := runBindCmd(mockClient, "k1", "--channel", "test", "--source-property", "k1_prop=foo", "--source-property", "foo=unknown")
+	assert.Error(t, err, "binding uses unknown property \"foo\" for Kamelet \"k1\"")
+
+	recorder.Validate()
+}
+
 func TestBindErrorCaseUnsupportedSinkType(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()

--- a/internal/command/bind_test.go
+++ b/internal/command/bind_test.go
@@ -102,7 +102,7 @@ func TestBindErrorCaseUnknownProperty(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindCmd(mockClient, "k1", "--channel", "test", "--source-property", "k1_prop=foo", "--source-property", "foo=unknown")
+	err := runBindCmd(mockClient, "k1", "--channel", "test", "--property", "k1_prop=foo", "--property", "foo=unknown")
 	assert.Error(t, err, "binding uses unknown property \"foo\" for Kamelet \"k1\"")
 
 	recorder.Validate()
@@ -115,7 +115,7 @@ func TestBindErrorCaseUnsupportedSinkType(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindCmd(mockClient, "k1", "--sink", "foo:test", "--source-property", "k1_prop=foo")
+	err := runBindCmd(mockClient, "k1", "--sink", "foo:test", "--property", "k1_prop=foo")
 	assert.Error(t, err, "unsupported sink type \"foo\"")
 
 	recorder.Validate()
@@ -128,7 +128,7 @@ func TestBindErrorCaseUnsupportedSinkExpression(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindCmd(mockClient, "k1", "--sink", "foo", "--source-property", "k1_prop=foo")
+	err := runBindCmd(mockClient, "k1", "--sink", "foo", "--property", "k1_prop=foo")
 	assert.Error(t, err, "unsupported sink expression \"foo\" - please use format <kind>:<name>")
 
 	recorder.Validate()
@@ -169,7 +169,7 @@ func TestBindToChannel(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindCmd(mockClient, "k1", "--channel", "test", "--source-property", "k1_prop=foo")
+	err := runBindCmd(mockClient, "k1", "--channel", "test", "--property", "k1_prop=foo")
 	assert.NilError(t, err)
 
 	recorder.Validate()
@@ -210,7 +210,7 @@ func TestBindToBroker(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindCmd(mockClient, "k2", "--broker", "test", "--source-property", "k2_prop=foo", "--source-property", "k2_optional=bar")
+	err := runBindCmd(mockClient, "k2", "--broker", "test", "--property", "k2_prop=foo", "--property", "k2_optional=bar")
 	assert.NilError(t, err)
 
 	recorder.Validate()
@@ -251,7 +251,7 @@ func TestBindToService(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindCmd(mockClient, "k3", "--service", "test", "--source-property", "k3_prop=foo")
+	err := runBindCmd(mockClient, "k3", "--service", "test", "--property", "k3_prop=foo")
 	assert.NilError(t, err)
 
 	recorder.Validate()
@@ -299,7 +299,7 @@ func TestBindAutoUpdate(t *testing.T) {
 
 	recorder.UpdateKameletBinding(binding, nil)
 
-	err := runBindCmd(mockClient, "k1", "--channel", "test", "--source-property", "k1_prop=foo")
+	err := runBindCmd(mockClient, "k1", "--channel", "test", "--property", "k1_prop=foo")
 	assert.NilError(t, err)
 
 	recorder.Validate()

--- a/internal/command/binding.go
+++ b/internal/command/binding.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var bindingExample = `
+  # Configure and manage a Kamelet binding.
+  kn-source-kamelet binding create|update|delete`
+
+// NewBindingCommand implements 'kn-source-kamelet binding' command
+func NewBindingCommand(p *KameletPluginParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "binding",
+		Short:   "Configure and manage a Kamelet binding.",
+		Example: bindingExample,
+	}
+
+	cmd.AddCommand(newBindingCreateCommand(p))
+	return cmd
+}

--- a/internal/command/binding_create.go
+++ b/internal/command/binding_create.go
@@ -41,11 +41,11 @@ var bindingCreateExample = `
   kn-source-kamelet binding create NAME
 
   # Add a binding properties
-  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value>`
+  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --property=<key>=<value>`
 
 // newBindingCreateCommand implements 'kn-source-kamelet bind' command
 func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
-	var sourceProperties []string
+	var properties []string
 	var source string
 	var sink string
 	var broker string
@@ -75,7 +75,7 @@ func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
 			options := CreateBindingOptions{
 				Name:             name,
 				Source:           source,
-				SourceProperties: sourceProperties,
+				SourceProperties: properties,
 				Sink:             sink,
 				Broker:           broker,
 				Channel:          channel,
@@ -100,7 +100,7 @@ func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")
 	flags.BoolVar(&force, "force", false, "Apply the changes even if the binding already exists.")
-	flags.StringArrayVar(&sourceProperties, "source-property", nil, `Add a source property in the form of "<key>=<value>"`)
+	flags.StringArrayVar(&properties, "property", nil, `Add a source property in the form of "<key>=<value>"`)
 	return cmd
 }
 

--- a/internal/command/binding_create.go
+++ b/internal/command/binding_create.go
@@ -81,6 +81,7 @@ func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
 				Channel:          channel,
 				Service:          service,
 				Force:            force,
+				CmdOut:           cmd.OutOrStdout(),
 			}
 
 			err = createBinding(client, p.Context, namespace, options)
@@ -192,9 +193,9 @@ func createBinding(client camelkv1alpha1.CamelV1alpha1Interface, ctx context.Con
 	}
 
 	if existed {
-		fmt.Printf("kamelet binding %q updated\n", name)
+		_, _ = fmt.Fprintf(options.CmdOut, "kamelet binding %q updated\n", name)
 	} else {
-		fmt.Printf("kamelet binding %q created\n", name)
+		_, _ = fmt.Fprintf(options.CmdOut, "kamelet binding %q created\n", name)
 	}
 
 	return nil

--- a/internal/command/binding_create.go
+++ b/internal/command/binding_create.go
@@ -262,8 +262,9 @@ func decodeSink(sink string) (corev1.ObjectReference, error) {
 }
 
 func verifyProperties(kamelet *v1alpha1.Kamelet, endpoint v1alpha1.Endpoint) error {
+	pMap, err := endpoint.Properties.GetPropertyMap()
+
 	if kamelet.Spec.Definition != nil && len(kamelet.Spec.Definition.Required) > 0 {
-		pMap, err := endpoint.Properties.GetPropertyMap()
 		if err != nil {
 			return err
 		}
@@ -277,6 +278,12 @@ func verifyProperties(kamelet *v1alpha1.Kamelet, endpoint v1alpha1.Endpoint) err
 			if !found {
 				return fmt.Errorf("binding is missing required property %q for Kamelet %q", reqProp, kamelet.Name)
 			}
+		}
+	}
+
+	for propName := range pMap {
+		if _, ok := kamelet.Spec.Definition.Properties[propName]; !ok {
+			return fmt.Errorf("binding uses unknown property %q for Kamelet %q", propName, kamelet.Name)
 		}
 	}
 

--- a/internal/command/binding_create.go
+++ b/internal/command/binding_create.go
@@ -1,0 +1,326 @@
+/*
+ * Copyright © 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	camelv1 "github.com/apache/camel-k/pkg/apis/camel/v1"
+	"github.com/apache/camel-k/pkg/apis/camel/v1alpha1"
+	camelkv1alpha1 "github.com/apache/camel-k/pkg/client/camel/clientset/versioned/typed/camel/v1alpha1"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	knerrors "knative.dev/client/pkg/errors"
+	"knative.dev/client/pkg/kn/commands"
+)
+
+var bindingCreateExample = `
+  # Create Kamelet binding with source and sink.
+  kn-source-kamelet binding create NAME
+
+  # Add a binding properties
+  kn-source-kamelet binding create NAME --kamelet=name --sink|broker|channel|service=<name> --source-property=<key>=<value> --sink-property=<key>=<value>`
+
+// newBindingCreateCommand implements 'kn-source-kamelet bind' command
+func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
+	printFlags := genericclioptions.NewPrintFlags("")
+
+	var sourceProperties []string
+	var sinkProperties []string
+	var source string
+	var sink string
+	var broker string
+	var channel string
+	var service string
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create Kamelet bindings and bind source to Knative broker, channel or service.",
+		Example: bindingCreateExample,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if len(args) != 1 {
+				return errors.New("'kn-source-kamelet binding create' requires the binding name as argument")
+			}
+			name := args[0]
+
+			namespace, err := p.GetNamespace(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := p.NewKameletClient()
+			if err != nil {
+				return err
+			}
+
+			options := CreateBindingOptions{
+				Name:             name,
+				Source:           source,
+				SourceProperties: sourceProperties,
+				Sink:             sink,
+				SinkProperties:   sinkProperties,
+				Broker:           broker,
+				Channel:          channel,
+				Service:          service,
+			}
+
+			binding, err := createBinding(client, p.Context, namespace, options)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			if printFlags.OutputFlagSpecified() {
+				printer, err := printFlags.ToPrinter()
+				if err != nil {
+					return err
+				}
+				return printer.PrintObj(binding, out)
+			}
+
+			return nil
+		},
+	}
+	flags := cmd.Flags()
+	commands.AddNamespaceFlags(flags, false)
+
+	flags.StringVar(&source, "kamelet", "", "Kamelet source.")
+	flags.StringVar(&sink, "sink", "", "Sink expression to define the binding sink.")
+	flags.StringVar(&broker, "broker", "", "Uses a broker as binding sink.")
+	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
+	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")
+	flags.StringArrayVar(&sourceProperties, "source-property", nil, `Add a source property in the form of "<key>=<value>"`)
+	flags.StringArrayVar(&sinkProperties, "sink-property", nil, `Add a sink property in the form of "<key>=<value>"`)
+
+	printFlags.AddFlags(cmd)
+	cmd.Flag("output").Usage = fmt.Sprintf("Output format. One of: %s.", strings.Join(append(printFlags.AllowedFormats(), "url"), "|"))
+	return cmd
+}
+
+func createBinding(client camelkv1alpha1.CamelV1alpha1Interface, ctx context.Context, namespace string, options CreateBindingOptions) (*v1alpha1.KameletBinding, error) {
+	kamelet, err := client.Kamelets(namespace).Get(ctx, options.Source, v1.GetOptions{})
+	if err != nil {
+		return nil, knerrors.GetError(err)
+	}
+
+	if !isEventSourceType(kamelet) {
+		return nil, fmt.Errorf("Kamelet %s is not an event source", options.Source)
+	}
+
+	sourceProps, err := parseProperties(options.SourceProperties)
+	if err != nil {
+		return nil, knerrors.GetError(err)
+	}
+	sourceEndpoint := v1alpha1.Endpoint{
+		Properties: &sourceProps,
+		Ref: &corev1.ObjectReference{
+			Kind:       v1alpha1.KameletKind,
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Name:       kamelet.Name,
+			Namespace:  kamelet.Namespace,
+		},
+	}
+
+	if err := verifyProperties(kamelet, sourceEndpoint); err != nil {
+		return nil, knerrors.GetError(err)
+	}
+
+	var sinkRef corev1.ObjectReference
+	if options.Sink != "" {
+		sinkRef, err = decodeSink(options.Sink)
+	} else if options.Broker != "" {
+		sinkRef, err = decodeSink("broker:" + options.Broker)
+	} else if options.Channel != "" {
+		sinkRef, err = decodeSink("channel:" + options.Channel)
+	} else if options.Service != "" {
+		sinkRef, err = decodeSink("service:" + options.Service)
+	} else {
+		err = fmt.Errorf("missing sink for binding - please use one of --sink, --broker, --channel, --service")
+	}
+
+	if err != nil {
+		return nil, knerrors.GetError(err)
+	}
+
+	if sinkRef.Namespace == "" {
+		sinkRef.Namespace = namespace
+	}
+
+	sinkProps, err := parseProperties(options.SinkProperties)
+	if err != nil {
+		return nil, knerrors.GetError(err)
+	}
+	sinkEndpoint := v1alpha1.Endpoint{
+		Properties: &sinkProps,
+		Ref:        &sinkRef,
+	}
+
+	name := nameFor(options.Name, options.Source, sinkRef)
+
+	binding := v1alpha1.KameletBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.KameletBindingSpec{
+			Source: sourceEndpoint,
+			Sink:   sinkEndpoint,
+		},
+	}
+
+	existed := false
+	_, err = client.KameletBindings(namespace).Create(ctx, &binding, v1.CreateOptions{})
+	if err != nil && k8serrors.IsAlreadyExists(err) {
+		existed = true
+
+		existing, err := client.KameletBindings(namespace).Get(ctx, binding.Name, v1.GetOptions{})
+		if err != nil {
+			return nil, knerrors.GetError(err)
+		}
+		// Update the custom resource
+		binding.ResourceVersion = existing.ResourceVersion
+		_, err = client.KameletBindings(namespace).Update(ctx, &binding, v1.UpdateOptions{})
+		if err != nil {
+			return nil, knerrors.GetError(err)
+		}
+	}
+
+	if !existed {
+		fmt.Printf("kamelet binding \"%s\" created\n", name)
+	} else {
+		fmt.Printf("kamelet binding \"%s\" updated\n", name)
+	}
+
+	return &binding, nil
+}
+
+func nameFor(name, source string, sinkRef corev1.ObjectReference) string {
+	if name != "" {
+		return name
+	}
+
+	generated := fmt.Sprintf("%s-to-%s-%s", source, sinkRef.Kind, sinkRef.Name)
+
+	generated = filepath.Base(generated)
+	generated = strings.Split(generated, ".")[0]
+	generated = strings.ToLower(generated)
+	generated = disallowedChars.ReplaceAllString(generated, "")
+	generated = strings.TrimFunc(generated, isDisallowedStartEndChar)
+
+	return generated
+}
+
+func decodeSink(sink string) (corev1.ObjectReference, error) {
+	ref := corev1.ObjectReference{}
+
+	if sinkExpression.MatchString(sink) {
+		groupNames := sinkExpression.SubexpNames()
+		for _, match := range sinkExpression.FindAllStringSubmatch(sink, -1) {
+			for idx, text := range match {
+				groupName := groupNames[idx]
+				switch groupName {
+				case "apiVersion":
+					ref.APIVersion = text
+				case "namespace":
+					ref.Namespace = text
+				case "kind":
+					ref.Kind = text
+				case "name":
+					ref.Name = text
+				}
+			}
+		}
+
+		if sinkType, ok := sinkTypes[ref.Kind]; ok {
+			if sinkType.Kind != "" {
+				ref.Kind = sinkType.Kind
+			}
+			if ref.APIVersion == "" && sinkType.APIVersion != "" {
+				ref.APIVersion = sinkType.APIVersion
+			}
+		} else {
+			return ref, fmt.Errorf("unsupported sink type %q", ref.Kind)
+		}
+	} else {
+		return ref, fmt.Errorf("unsupported sink expression %q - please use format <kind>:<name>", sink)
+	}
+
+	return ref, nil
+}
+
+func verifyProperties(kamelet *v1alpha1.Kamelet, endpoint v1alpha1.Endpoint) error {
+	if kamelet.Spec.Definition != nil && len(kamelet.Spec.Definition.Required) > 0 {
+		pMap, err := endpoint.Properties.GetPropertyMap()
+		if err != nil {
+			return err
+		}
+		for _, reqProp := range kamelet.Spec.Definition.Required {
+			found := false
+			if endpoint.Properties != nil {
+				if _, contains := pMap[reqProp]; contains {
+					found = true
+				}
+			}
+			if !found {
+				return fmt.Errorf("binding is missing required property %q for Kamelet %q", reqProp, kamelet.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseProperties(properties []string) (v1alpha1.EndpointProperties, error) {
+	props := make(map[string]string)
+	for _, p := range properties {
+		key, value, err := parseProperty(p)
+		if err != nil {
+			continue
+		}
+		props[key] = value
+	}
+	return asEndpointProperties(props)
+}
+
+func asEndpointProperties(props map[string]string) (v1alpha1.EndpointProperties, error) {
+	if len(props) == 0 {
+		return v1alpha1.EndpointProperties{}, nil
+	}
+	data, err := json.Marshal(props)
+	if err != nil {
+		return v1alpha1.EndpointProperties{}, err
+	}
+	return v1alpha1.EndpointProperties{
+		RawMessage: camelv1.RawMessage(data),
+	}, nil
+}
+
+func parseProperty(prop string) (string, string, error) {
+	parts := strings.SplitN(prop, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf(`property %q does not follow format "<key>=<value>"`, prop)
+	}
+	return parts[0], parts[1], nil
+}

--- a/internal/command/binding_create.go
+++ b/internal/command/binding_create.go
@@ -95,7 +95,7 @@ func newBindingCreateCommand(p *KameletPluginParams) *cobra.Command {
 	commands.AddNamespaceFlags(flags, false)
 
 	flags.StringVar(&source, "kamelet", "", "Kamelet source.")
-	flags.StringVar(&sink, "sink", "", "Sink expression to define the binding sink.")
+	flags.StringVarP(&sink, "sink", "s", "", "Sink expression to define the binding sink.")
 	flags.StringVar(&broker, "broker", "", "Uses a broker as binding sink.")
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")

--- a/internal/command/binding_create_test.go
+++ b/internal/command/binding_create_test.go
@@ -145,7 +145,6 @@ func TestBindingCreateToChannel(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Channel",
 					APIVersion: messagingv1.SchemeGroupVersion.String(),
@@ -187,7 +186,6 @@ func TestBindingCreateToBroker(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Broker",
 					APIVersion: eventingv1.SchemeGroupVersion.String(),
@@ -229,7 +227,6 @@ func TestBindingCreateToService(t *testing.T) {
 				},
 			},
 			Sink: v1alpha1.Endpoint{
-				Properties: &v1alpha1.EndpointProperties{},
 				Ref: &corev1.ObjectReference{
 					Kind:       "Service",
 					APIVersion: servingv1.SchemeGroupVersion.String(),

--- a/internal/command/binding_create_test.go
+++ b/internal/command/binding_create_test.go
@@ -93,6 +93,19 @@ func TestBindingCreateErrorCaseMissingRequiredProperty(t *testing.T) {
 	recorder.Validate()
 }
 
+func TestBindingCreateErrorCaseUnknownProperty(t *testing.T) {
+	mockClient := client.NewMockClient(t)
+	recorder := mockClient.Recorder()
+
+	kamelet := createKamelet("k1")
+	recorder.Get(kamelet, nil)
+
+	err := runBindingCreateCmd(mockClient, "k1-to-sink", "--kamelet", "k1", "--channel", "test", "--source-property", "k1_prop=foo", "--source-property", "foo=unknown")
+	assert.Error(t, err, "binding uses unknown property \"foo\" for Kamelet \"k1\"")
+
+	recorder.Validate()
+}
+
 func TestBindingCreateErrorCaseUnsupportedSinkType(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()

--- a/internal/command/binding_create_test.go
+++ b/internal/command/binding_create_test.go
@@ -101,7 +101,7 @@ func TestBindingCreateErrorCaseUnknownProperty(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindingCreateCmd(mockClient, "k1-to-sink", "--kamelet", "k1", "--channel", "test", "--source-property", "k1_prop=foo", "--source-property", "foo=unknown")
+	err := runBindingCreateCmd(mockClient, "k1-to-sink", "--kamelet", "k1", "--channel", "test", "--property", "k1_prop=foo", "--property", "foo=unknown")
 	assert.Error(t, err, "binding uses unknown property \"foo\" for Kamelet \"k1\"")
 
 	recorder.Validate()
@@ -114,7 +114,7 @@ func TestBindingCreateErrorCaseUnsupportedSinkType(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindingCreateCmd(mockClient, "k1-to-foo", "--kamelet", "k1", "--sink", "foo:test", "--source-property", "k1_prop=foo")
+	err := runBindingCreateCmd(mockClient, "k1-to-foo", "--kamelet", "k1", "--sink", "foo:test", "--property", "k1_prop=foo")
 	assert.Error(t, err, "unsupported sink type \"foo\"")
 
 	recorder.Validate()
@@ -127,7 +127,7 @@ func TestBindingCreateErrorCaseUnsupportedSinkExpression(t *testing.T) {
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	err := runBindingCreateCmd(mockClient, "k1-to-foo", "--kamelet", "k1", "--sink", "foo", "--source-property", "k1_prop=foo")
+	err := runBindingCreateCmd(mockClient, "k1-to-foo", "--kamelet", "k1", "--sink", "foo", "--property", "k1_prop=foo")
 	assert.Error(t, err, "unsupported sink expression \"foo\" - please use format <kind>:<name>")
 
 	recorder.Validate()
@@ -169,7 +169,7 @@ func TestBindingCreateErrorCaseAlreadyExists(t *testing.T) {
 		},
 	}, k8serrors.NewAlreadyExists(v1alpha1.Resource("bindings"), "k1-to-channel-test"))
 
-	err := runBindingCreateCmd(mockClient, "k1-to-channel", "--kamelet", "k1", "--channel", "test", "--source-property", "k1_prop=foo")
+	err := runBindingCreateCmd(mockClient, "k1-to-channel", "--kamelet", "k1", "--channel", "test", "--property", "k1_prop=foo")
 	assert.Error(t, err, "kamelet binding with name \"k1-to-channel\" already exists. Use --force to recreate the binding")
 
 	recorder.Validate()
@@ -210,7 +210,7 @@ func TestBindingCreateToChannel(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindingCreateCmd(mockClient, "k1-to-channel", "--kamelet", "k1", "--channel", "test", "--source-property", "k1_prop=foo")
+	err := runBindingCreateCmd(mockClient, "k1-to-channel", "--kamelet", "k1", "--channel", "test", "--property", "k1_prop=foo")
 	assert.NilError(t, err)
 
 	recorder.Validate()
@@ -251,7 +251,7 @@ func TestBindingCreateToBroker(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindingCreateCmd(mockClient, "k2-to-broker", "--kamelet", "k2", "--broker", "test", "--source-property", "k2_prop=foo", "--source-property", "k2_optional=bar")
+	err := runBindingCreateCmd(mockClient, "k2-to-broker", "--kamelet", "k2", "--broker", "test", "--property", "k2_prop=foo", "--property", "k2_optional=bar")
 	assert.NilError(t, err)
 
 	recorder.Validate()
@@ -292,7 +292,7 @@ func TestBindingCreateToService(t *testing.T) {
 			},
 		},
 	}, nil)
-	err := runBindingCreateCmd(mockClient, "k3-to-service", "--kamelet", "k3", "--service", "test", "--source-property", "k3_prop=foo")
+	err := runBindingCreateCmd(mockClient, "k3-to-service", "--kamelet", "k3", "--service", "test", "--property", "k3_prop=foo")
 	assert.NilError(t, err)
 
 	recorder.Validate()

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-// KnParams for creating commands. Useful for inserting mocks for testing.
+// KameletPluginParams for creating commands. Useful for inserting mocks for testing.
 type KameletPluginParams struct {
 	*commands.KnParams
 	Context          context.Context
@@ -82,4 +82,16 @@ func (params *KameletPluginParams) newKameletClient() (camelkv1alpha1.CamelV1alp
 	}
 
 	return client.CamelV1alpha1(), nil
+}
+
+// CreateBindingOptions holding settings and options on the create binding command
+type CreateBindingOptions struct {
+	Name             string
+	Source           string
+	SourceProperties []string
+	Sink             string
+	SinkProperties   []string
+	Broker           string
+	Channel          string
+	Service          string
 }

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"context"
+	"io"
 
 	corev1 "k8s.io/api/core/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -94,4 +95,5 @@ type CreateBindingOptions struct {
 	Channel          string
 	Service          string
 	Force            bool
+	CmdOut           io.Writer
 }

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -93,4 +93,5 @@ type CreateBindingOptions struct {
 	Broker           string
 	Channel          string
 	Service          string
+	Force            bool
 }

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -44,7 +44,7 @@ var (
 			Kind:       "Broker",
 			APIVersion: eventingv1.SchemeGroupVersion.String(),
 		},
-		"service": {
+		"ksvc": {
 			Kind:       "Service",
 			APIVersion: servingv1.SchemeGroupVersion.String(),
 		},
@@ -90,7 +90,6 @@ type CreateBindingOptions struct {
 	Source           string
 	SourceProperties []string
 	Sink             string
-	SinkProperties   []string
 	Broker           string
 	Channel          string
 	Service          string

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -41,6 +41,7 @@ func NewSourceKameletCommand() *cobra.Command {
 	rootCmd.AddCommand(command.NewListTypesCommand(p))
 	rootCmd.AddCommand(command.NewDescribeTypeCommand(p))
 	rootCmd.AddCommand(command.NewBindCommand(p))
+	rootCmd.AddCommand(command.NewBindingCommand(p))
 	rootCmd.AddCommand(command.NewVersionCommand())
 
 	return rootCmd


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add Kamelet binding command with first subcommand `create`
- Refactor bind command to work as a shortcut for `binding create`
- `binding create` follows the common kn conventions to use name as positional argument and `--kamelet` as source
- Update README with command information

Sample for new `binding create` subcommand:

```
kn source kamelet binding create telegram-to-broker --kamelet telegram-source --broker default --sourceProperty=token=xxx
```