### PR TITLE
Rename list-types and describe-type to "list" and "describe"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 
 # Binaries
 kn-source-kamelet
+
+# Vendor specific files
+vendor/**/BUILD.bazel
+vendor/**/OWNERS
+vendor/**/OWNERS_ALIASES

--- a/internal/command/describe.go
+++ b/internal/command/describe.go
@@ -36,23 +36,22 @@ import (
 
 var describeExample = `
   # Describe given Kamelets
-  kn-source-kamelet describe-type NAME
+  kn-source-kamelet describe NAME
 
   # Describe given Kamelets in YAML output format
-  kn-source-kamelet describe-type NAME -o yaml`
+  kn-source-kamelet describe NAME -o yaml`
 
-// NewDescribeTypeCommand implements 'kn-source-kamelet describe-type' command
-func NewDescribeTypeCommand(p *KameletPluginParams) *cobra.Command {
+// NewDescribeCommand implements 'kn-source-kamelet describe' command
+func NewDescribeCommand(p *KameletPluginParams) *cobra.Command {
 	printFlags := genericclioptions.NewPrintFlags("")
 
 	cmd := &cobra.Command{
-		Use:     "describe-type",
+		Use:     "describe",
 		Short:   "Show details of given Kamelet source type",
-		Aliases: []string{"dt"},
 		Example: describeExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
-				return errors.New("'kn-source-kamelet describe-type' requires the Kamelet name given as single argument")
+				return errors.New("'kn-source-kamelet describe' requires the Kamelet name given as single argument")
 			}
 			name := args[0]
 

--- a/internal/command/describe_test.go
+++ b/internal/command/describe_test.go
@@ -30,38 +30,38 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestDescribeTypeSetup(t *testing.T) {
+func TestDescribeSetup(t *testing.T) {
 	p := KameletPluginParams{
 		Context: context.TODO(),
 	}
 
-	describeCmd := NewDescribeTypeCommand(&p)
-	assert.Equal(t, describeCmd.Use, "describe-type")
+	describeCmd := NewDescribeCommand(&p)
+	assert.Equal(t, describeCmd.Use, "describe")
 	assert.Equal(t, describeCmd.Short, "Show details of given Kamelet source type")
 	assert.Assert(t, describeCmd.RunE != nil)
 }
-func TestDescribeTypeErrorCase(t *testing.T) {
+func TestDescribeErrorCase(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
-	_, err := runDescribeTypeCmd(mockClient)
-	assert.Error(t, err, "'kn-source-kamelet describe-type' requires the Kamelet name given as single argument")
+	_, err := runDescribeCmd(mockClient)
+	assert.Error(t, err, "'kn-source-kamelet describe' requires the Kamelet name given as single argument")
 	recorder.Validate()
 }
 
-func TestDescribeTypeErrorCaseNotFound(t *testing.T) {
+func TestDescribeErrorCaseNotFound(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, errors.New("not found"))
 
-	_, err := runDescribeTypeCmd(mockClient, "k1")
+	_, err := runDescribeCmd(mockClient, "k1")
 	assert.Error(t, err, "not found")
 	recorder.Validate()
 }
 
-func TestDescribeTypeErrorCaseNoEventSource(t *testing.T) {
+func TestDescribeErrorCaseNoEventSource(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
@@ -71,19 +71,19 @@ func TestDescribeTypeErrorCaseNoEventSource(t *testing.T) {
 	}
 	recorder.Get(kamelet, nil)
 
-	_, err := runDescribeTypeCmd(mockClient, "k1")
+	_, err := runDescribeCmd(mockClient, "k1")
 	assert.Error(t, err, "Kamelet k1 is not an event source")
 	recorder.Validate()
 }
 
-func TestDescribeTypeOutput(t *testing.T) {
+func TestDescribeOutput(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	output, err := runDescribeTypeCmd(mockClient, "k1")
+	output, err := runDescribeCmd(mockClient, "k1")
 	assert.NilError(t, err)
 
 	outputLines := strings.Split(output, "\n")
@@ -105,14 +105,14 @@ func TestDescribeTypeOutput(t *testing.T) {
 	recorder.Validate()
 }
 
-func TestDescribeTypeVerboseOutput(t *testing.T) {
+func TestDescribeVerboseOutput(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	output, err := runDescribeTypeCmd(mockClient, "k1", "--verbose")
+	output, err := runDescribeCmd(mockClient, "k1", "--verbose")
 	assert.NilError(t, err)
 
 	outputLines := strings.Split(output, "\n")
@@ -138,14 +138,14 @@ func TestDescribeTypeVerboseOutput(t *testing.T) {
 	recorder.Validate()
 }
 
-func TestDescribeTypeURL(t *testing.T) {
+func TestDescribeURL(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	kamelet := createKamelet("k1")
 	recorder.Get(kamelet, nil)
 
-	output, err := runDescribeTypeCmd(mockClient, "k1", "-o", "url")
+	output, err := runDescribeCmd(mockClient, "k1", "-o", "url")
 	assert.NilError(t, err, "Kamelet should be described with url as output")
 
 	outputLines := strings.Split(output, "\n")
@@ -154,7 +154,7 @@ func TestDescribeTypeURL(t *testing.T) {
 	recorder.Validate()
 }
 
-func runDescribeTypeCmd(c *client.MockClient, options ...string) (string, error) {
+func runDescribeCmd(c *client.MockClient, options ...string) (string, error) {
 	p := KameletPluginParams{
 		KnParams: &commands.KnParams{},
 		Context:  context.TODO(),
@@ -163,9 +163,9 @@ func runDescribeTypeCmd(c *client.MockClient, options ...string) (string, error)
 		},
 	}
 
-	describeCmd, _, output := commands.CreateSourcesTestKnCommand(NewDescribeTypeCommand(&p), p.KnParams)
+	describeCmd, _, output := commands.CreateSourcesTestKnCommand(NewDescribeCommand(&p), p.KnParams)
 
-	args := []string{"describe-type"}
+	args := []string{"describe"}
 	args = append(args, options...)
 	describeCmd.SetArgs(args)
 	err := describeCmd.Execute()

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -33,19 +33,19 @@ import (
 
 var listExample = `
   # List available Kamelets
-  kn-source-kamelet list-types
+  kn-source-kamelet list
 
   # List available Kamelets in YAML output format
-  kn-source-kamelet list-types -o yaml`
+  kn-source-kamelet list -o yaml`
 
-// NewListTypesCommand implements 'kn-source-kamelet list-types' command
-func NewListTypesCommand(p *KameletPluginParams) *cobra.Command {
+// NewListCommand implements 'kn-source-kamelet list' command
+func NewListCommand(p *KameletPluginParams) *cobra.Command {
 	kameletListFlags := flags.NewListPrintFlags(ListHandlers)
 
 	cmd := &cobra.Command{
-		Use:     "list-types",
+		Use:     "list",
 		Short:   "List available Kamelet source types",
-		Aliases: []string{"lst"},
+		Aliases: []string{"ls"},
 		Example: listExample,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			namespace, err := p.GetNamespace(cmd)
@@ -88,7 +88,7 @@ func NewListTypesCommand(p *KameletPluginParams) *cobra.Command {
 	return cmd
 }
 
-// ListHandlers handles printing human readable table for `kn-source-kamelet list-types` command's output
+// ListHandlers handles printing human readable table for `kn-source-kamelet list` command's output
 func ListHandlers(h hprinters.PrintHandler) {
 	kameletColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Namespace", Type: "string", Description: "Namespace of the Kamelet instance", Priority: 0},

--- a/internal/command/list_test.go
+++ b/internal/command/list_test.go
@@ -30,18 +30,18 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestListTypesSetup(t *testing.T) {
+func TestListSetup(t *testing.T) {
 	p := KameletPluginParams{
 		Context: context.TODO(),
 	}
 
-	listCmd := NewListTypesCommand(&p)
-	assert.Equal(t, listCmd.Use, "list-types")
+	listCmd := NewListCommand(&p)
+	assert.Equal(t, listCmd.Use, "list")
 	assert.Equal(t, listCmd.Short, "List available Kamelet source types")
 	assert.Assert(t, listCmd.RunE != nil)
 }
 
-func TestListTypesOutput(t *testing.T) {
+func TestListOutput(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
@@ -51,7 +51,7 @@ func TestListTypesOutput(t *testing.T) {
 	kameletList := &camelkapis.KameletList{Items: []camelkapis.Kamelet{*kamelet1, *kamelet2, *kamelet3}}
 	recorder.List(kameletList, nil)
 
-	output, err := runListTypesCmd(mockClient)
+	output, err := runListCmd(mockClient)
 	assert.NilError(t, err)
 
 	outputLines := strings.Split(output, "\n")
@@ -64,12 +64,12 @@ func TestListTypesOutput(t *testing.T) {
 	recorder.Validate()
 }
 
-func TestListTypesEmpty(t *testing.T) {
+func TestListEmpty(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
 	recorder.List(&camelkapis.KameletList{}, nil)
-	output, err := runListTypesCmd(mockClient)
+	output, err := runListCmd(mockClient)
 	assert.NilError(t, err)
 
 	assert.Assert(t, util.ContainsAll(output, "No", "resources", "found"))
@@ -77,7 +77,7 @@ func TestListTypesEmpty(t *testing.T) {
 	recorder.Validate()
 }
 
-func TestListTypesNoReadyReasonOutput(t *testing.T) {
+func TestListNoReadyReasonOutput(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
@@ -93,7 +93,7 @@ func TestListTypesNoReadyReasonOutput(t *testing.T) {
 	kameletList := &camelkapis.KameletList{Items: []camelkapis.Kamelet{*kamelet1, *kamelet2, *kamelet3}}
 	recorder.List(kameletList, nil)
 
-	output, err := runListTypesCmd(mockClient)
+	output, err := runListCmd(mockClient)
 	assert.NilError(t, err)
 
 	outputLines := strings.Split(output, "\n")
@@ -106,7 +106,7 @@ func TestListTypesNoReadyReasonOutput(t *testing.T) {
 	recorder.Validate()
 }
 
-func TestListTypesAllNamespace(t *testing.T) {
+func TestListAllNamespace(t *testing.T) {
 	mockClient := client.NewMockClient(t)
 	recorder := mockClient.Recorder()
 
@@ -116,7 +116,7 @@ func TestListTypesAllNamespace(t *testing.T) {
 	kameletList := &camelkapis.KameletList{Items: []camelkapis.Kamelet{*kamelet1, *kamelet2, *kamelet3}}
 	recorder.List(kameletList, nil)
 
-	output, err := runListTypesCmd(mockClient, "--all-namespaces")
+	output, err := runListCmd(mockClient, "--all-namespaces")
 	assert.NilError(t, err)
 
 	outputLines := strings.Split(output, "\n")
@@ -128,7 +128,7 @@ func TestListTypesAllNamespace(t *testing.T) {
 	recorder.Validate()
 }
 
-func runListTypesCmd(c *client.MockClient, options ...string) (string, error) {
+func runListCmd(c *client.MockClient, options ...string) (string, error) {
 	p := KameletPluginParams{
 		KnParams: &commands.KnParams{},
 		Context:  context.TODO(),
@@ -137,9 +137,9 @@ func runListTypesCmd(c *client.MockClient, options ...string) (string, error) {
 		},
 	}
 
-	listCmd, _, output := commands.CreateSourcesTestKnCommand(NewListTypesCommand(&p), p.KnParams)
+	listCmd, _, output := commands.CreateSourcesTestKnCommand(NewListCommand(&p), p.KnParams)
 
-	args := []string{"list-types"}
+	args := []string{"list"}
 	args = append(args, options...)
 	listCmd.SetArgs(args)
 	err := listCmd.Execute()

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -38,8 +38,8 @@ func NewSourceKameletCommand() *cobra.Command {
 	}
 	p.Initialize()
 
-	rootCmd.AddCommand(command.NewListTypesCommand(p))
-	rootCmd.AddCommand(command.NewDescribeTypeCommand(p))
+	rootCmd.AddCommand(command.NewListCommand(p))
+	rootCmd.AddCommand(command.NewDescribeCommand(p))
 	rootCmd.AddCommand(command.NewBindCommand(p))
 	rootCmd.AddCommand(command.NewBindingCommand(p))
 	rootCmd.AddCommand(command.NewVersionCommand())


### PR DESCRIPTION
# Changes

- Rename list-types and describe-type to "list" and "describe" respectively

Fixes #51 
