### PR TITLE
fix(#104): Add option to customize cloud events settings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,7 +138,10 @@ Flags:
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
   -s  --sink string                   Sink expression to define the binding sink.
-      --property stringArray   Add a source property in the form of "<key>=<value>"
+      --property stringArray          Add a source property in the form of "<key>=<value>"
+      --ce-override stringArray       Customize cloud events property in the form of "<key>=<value>"
+      --ce-spec string                Customize cloud events spec version provided to the binding sink.
+      --ce-type string                Customize cloud events type provided to the binding sink.
 ----
 
 ==== `binding list`
@@ -199,7 +202,10 @@ Flags:
   -n, --namespace string              Specify the namespace to operate in.
       --service string                Uses a Knative service as binding sink.
   -s  --sink string                   Sink expression to define the binding sink.
-      --property stringArray   Add a source property in the form of "<key>=<value>"
+      --property stringArray          Add a source property in the form of "<key>=<value>"
+      --ce-override stringArray       Customize cloud events property in the form of "<key>=<value>"
+      --ce-spec string                Customize cloud events spec version provided to the binding sink.
+      --ce-type string                Customize cloud events type provided to the binding sink.
 ----
 
 === `version`

--- a/internal/command/bind.go
+++ b/internal/command/bind.go
@@ -38,6 +38,9 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	var broker string
 	var channel string
 	var service string
+	var cloudEventsOverride []string
+	var cloudEventsSpecVersion string
+	var cloudEventsType string
 	cmd := &cobra.Command{
 		Use:     "bind",
 		Short:   "Create Kamelet bindings and bind source to Knative broker, channel or service.",
@@ -64,15 +67,18 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 			}
 
 			options := CreateBindingOptions{
-				Name:             name,
-				Source:           source,
-				SourceProperties: properties,
-				Sink:             sink,
-				Broker:           broker,
-				Channel:          channel,
-				Service:          service,
-				Force:            true,
-				CmdOut:           cmd.OutOrStdout(),
+				Name:                   name,
+				Source:                 source,
+				SourceProperties:       properties,
+				Sink:                   sink,
+				CloudEventsOverride:    cloudEventsOverride,
+				CloudEventsSpecVersion: cloudEventsSpecVersion,
+				CloudEventsType:        cloudEventsType,
+				Broker:                 broker,
+				Channel:                channel,
+				Service:                service,
+				Force:                  true,
+				CmdOut:                 cmd.OutOrStdout(),
 			}
 
 			err = createBinding(client, p.Context, namespace, options)
@@ -92,5 +98,8 @@ func NewBindCommand(p *KameletPluginParams) *cobra.Command {
 	flags.StringVar(&channel, "channel", "", "Uses a channel as binding sink.")
 	flags.StringVar(&service, "service", "", "Uses a Knative service as binding sink.")
 	flags.StringArrayVar(&properties, "property", nil, `Add a source property in the form of "<key>=<value>"`)
+	flags.StringVar(&cloudEventsSpecVersion, "ce-spec", "", "Customize cloud events spec version provided to the binding sink.")
+	flags.StringVar(&cloudEventsType, "ce-type", "", "Customize cloud events type provided to the binding sink.")
+	flags.StringArrayVar(&cloudEventsOverride, "ce-override", nil, `Customize cloud events property in the form of "<key>=<value>"`)
 	return cmd
 }

--- a/internal/command/helpers_test.go
+++ b/internal/command/helpers_test.go
@@ -102,7 +102,8 @@ func createKameletBindingInNamespace(bindingName string, kameletName string,
 				},
 			},
 			Sink: camelkv1alpha1.Endpoint{
-				Ref: sink,
+				Properties: &camelkv1alpha1.EndpointProperties{},
+				Ref:        sink,
 			},
 		},
 	}

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -88,13 +88,16 @@ func (params *KameletPluginParams) newKameletClient() (camelkv1alpha1.CamelV1alp
 
 // CreateBindingOptions holding settings and options on the create binding command
 type CreateBindingOptions struct {
-	Name             string
-	Source           string
-	SourceProperties []string
-	Sink             string
-	Broker           string
-	Channel          string
-	Service          string
-	Force            bool
-	CmdOut           io.Writer
+	Name                   string
+	Source                 string
+	SourceProperties       []string
+	CloudEventsOverride    []string
+	CloudEventsSpecVersion string
+	CloudEventsType        string
+	Sink                   string
+	Broker                 string
+	Channel                string
+	Service                string
+	Force                  bool
+	CmdOut                 io.Writer
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Allow users to specify custom cloud event fields when creating a Kamelet binding. The settings affect the cloud event that is created as part of the Knative sink (broker,channel, service). By default the binding creates default values in generated cloud events. With this change users can specify
- Cloud events type
- Cloud events spec version (default=1.0)

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Users are able to specify custom cloud event fields when creating a Kamelet binding. The settings affect the cloud event that is created as part of the Knative sink (broker,channel, service). Users can specify custom cloud event type and spec version settings.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
